### PR TITLE
Enable Orca and ability to build from a commit SHA

### DIFF
--- a/centos7/run_build_container.sh
+++ b/centos7/run_build_container.sh
@@ -1,5 +1,5 @@
-#!/bin/sh
+#!/bin/bash -x
 
 BUILD_DIR="/opt/build"
 
-docker run -v `pwd`:$BUILD_DIR -w $BUILD_DIR centos:7.1.1503 bash -c "${BUILD_DIR}/build.sh"
+docker run -v `pwd`:$BUILD_DIR -w $BUILD_DIR centos:7.2.1511 bash -c "${BUILD_DIR}/build.sh $*" | tee build.log 2>&1


### PR DESCRIPTION
Enable Orca and ability to build from a commit SHA.

run_build_container.sh now takes the following options:
>   --enable-orca|-o -- enable the Orca optimizer in the build
>   --with-miniconda|-m -- build with miniconda (not fully working yet)
>   --use-sha|-s -- clone the gpdb repository with the passed commit SHA

You can run this as follows:
> $ ./run_build_container.sh --use-sha 8e001facc8bc60aa5d87c605216d539db58f66fa --enable-orca